### PR TITLE
calling code from ucb_default_content.install to create a 404 page

### DIFF
--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -7,6 +7,7 @@ use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\node\Entity\Node;
 use \Drupal\Core\Url;
+use Drupal\ucb_default_content\DefaultContent;
 
 /**
  * A Drush commandfile.
@@ -98,7 +99,12 @@ final class UcbDrushCommands extends DrushCommands {
   }
 
 
+  /**
+   * Create default 404 page.
+   */
+  #[CLI\Command(name: 'ucb_drush_commands:create-404', aliases: ['c404'])]
+  #[CLI\Usage(name: 'ucb_drush_commands:create-404', description: 'Create default 404 page')]
   public function create404Page() {
-    _create_404_page();
+    DefaultContent::create_404_page();
   }
 }

--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\ucb_drush_commands\Drush\Commands;
 
+use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
+use Drupal\ucb_default_content\DefaultContent;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\node\Entity\Node;
-use \Drupal\Core\Url;
-use Drupal\ucb_default_content\DefaultContent;
 
 /**
  * A Drush commandfile.
@@ -25,7 +25,7 @@ final class UcbDrushCommands extends DrushCommands {
    * Constructs a UcbDrushCommands object.
    */
   public function __construct(
-    DefaultContent $defaultContent
+    DefaultContent $defaultContent,
   ) {
     parent::__construct();
     $this->defaultContent = $defaultContent;
@@ -50,10 +50,7 @@ final class UcbDrushCommands extends DrushCommands {
     $myfile = fopen("sites/default/files/migration-report.html", "r");
     $report = fread($myfile, filesize("sites/default/files/migration-report.html"));
 
-
-
-    $node = null;
-
+    $node = NULL;
 
     try {
       $this->logger()->success(dt("Test 1"));
@@ -70,12 +67,11 @@ final class UcbDrushCommands extends DrushCommands {
       $this->logger()->success(dt("Test 5"));
 
     }
-    catch(\Exception $e) {
+    catch (\Exception $e) {
       $this->logger()->success(dt($e->getMessage()));
     }
 
-    if(is_null($node))
-    {
+    if (is_null($node)) {
       $node = Node::create([
         'type' => 'basic_page',
         'title' => 'Migration Report',
@@ -88,9 +84,8 @@ final class UcbDrushCommands extends DrushCommands {
       $node->save();
       fclose($myfile);
     }
-    else
-    {
-      $node->set('body',  ['value' => $report, 'format' => 'full_html']);
+    else {
+      $node->set('body', ['value' => $report, 'format' => 'full_html']);
       $node->save();
     }
   }
@@ -109,6 +104,7 @@ final class UcbDrushCommands extends DrushCommands {
   #[CLI\Command(name: 'ucb_drush_commands:create-404', aliases: ['c404'])]
   #[CLI\Usage(name: 'ucb_drush_commands:create-404', description: 'Create default 404 page')]
   public function create404Page() {
-    $this->defaultContent->create_404_page();
+    $this->defaultContent->create404Page();
   }
+
 }

--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -15,11 +15,20 @@ use Drupal\ucb_default_content\DefaultContent;
 final class UcbDrushCommands extends DrushCommands {
 
   /**
+   * The DefaultContent service.
+   *
+   * @var \Drupal\ucb_default_content\DefaultContent
+   */
+  protected $defaultContent;
+
+  /**
    * Constructs a UcbDrushCommands object.
    */
   public function __construct(
+    DefaultContent $defaultContent
   ) {
     parent::__construct();
+    $this->defaultContent = $defaultContent;
   }
 
   /**
@@ -27,9 +36,9 @@ final class UcbDrushCommands extends DrushCommands {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('ucb_default_content')
     );
   }
-
 
   /**
    * Store a report.
@@ -86,10 +95,6 @@ final class UcbDrushCommands extends DrushCommands {
     }
   }
 
-
-
-
-
   /**
    * Convert shortcodes in to CKEditor5 HTML.
    */
@@ -98,13 +103,12 @@ final class UcbDrushCommands extends DrushCommands {
   public function shortcodeConvert($arg1, $options = ['option-name' => 'default']) {
   }
 
-
   /**
    * Create default 404 page.
    */
   #[CLI\Command(name: 'ucb_drush_commands:create-404', aliases: ['c404'])]
   #[CLI\Usage(name: 'ucb_drush_commands:create-404', description: 'Create default 404 page')]
   public function create404Page() {
-    DefaultContent::create_404_page();
+    $this->defaultContent->create_404_page();
   }
 }

--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -97,4 +97,8 @@ final class UcbDrushCommands extends DrushCommands {
   public function shortcodeConvert($arg1, $options = ['option-name' => 'default']) {
   }
 
+
+  public function create404Page() {
+    _create_404_page();
+  }
 }


### PR DESCRIPTION
Drush command to create 404 page after site migration. Requires code from CuBoulder/ucb_default_content#14

closes #1 