### PR TITLE
Adds Site Manager administerusersbyrole command to activate custom permissions

### DIFF
--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -325,5 +325,54 @@ final class UcbDrushCommands extends DrushCommands {
             $service->showSyndicationFields();
         }
     }
-}
 
+
+    /**
+     * Grants permissions to Site Manager and updates administerusersbyrole settings.
+     */
+    #[CLI\Command(name: 'ucb_drush_commands:update-site-manager-permissions', aliases: ['usmp'])]
+    #[CLI\Usage(name: 'ucb_drush_commands:update-site-manager-permissions', description: 'Grants permissions to Site Manager and updates administerusersbyrole settings')]
+    public function updateSiteManagerPermissions() {
+        // Ensure that the "administerusersbyrole" module is fully installed before proceeding.
+        if (!\Drupal::moduleHandler()->moduleExists('administerusersbyrole')) {
+            $this->logger()->error('administerusersbyrole module is not installed. Skipping role and config update.');
+            return;
+        }
+
+        // Load and update administerusersbyrole.settings.yml, in case this is a pre-existing site
+        $config = \Drupal::configFactory()->getEditable('administerusersbyrole.settings');
+        $config->merge([
+            'roles' => [
+                'site_manager' => 'perm',
+            ],
+        ])->save();
+
+        $this->logger()->notice('Updated administerusersbyrole.settings.yml to set site_manager to "perm".');
+
+        // Permissions for site_manager.
+        $site_manager_permissions = [
+            'view users by role',
+            'cancel users by role',
+            'edit users by role',
+            'role-assign users by role',
+            'cancel users with role site_manager',
+            'edit users with role site_manager',
+            'view users with role site_manager',
+            'role-assign users with role site_manager',
+        ];
+
+        // Update permissions for site_manager.
+        $role = \Drupal\user\Entity\Role::load('site_manager');
+        if ($role) {
+            foreach ($site_manager_permissions as $permission) {
+                if (!$role->hasPermission($permission)) {
+                    $role->grantPermission($permission);
+                }
+            }
+            $role->save();
+            $this->logger()->notice("Updated permissions for site_manager role.");
+        } else {
+            $this->logger()->error("site_manager role does not exist.");
+        }
+    }
+}

--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -344,6 +344,7 @@ final class UcbDrushCommands extends DrushCommands {
         $config->merge([
             'roles' => [
                 'site_manager' => 'perm',
+                'site_owner' => 'perm',
             ],
         ])->save();
 
@@ -359,6 +360,10 @@ final class UcbDrushCommands extends DrushCommands {
             'edit users with role site_manager',
             'view users with role site_manager',
             'role-assign users with role site_manager',
+            'cancel users with role site_owner',
+            'edit users with role site_owner',
+            'view users with role site_owner',
+            'role-assign users with role site_owner',
         ];
 
         // Update permissions for site_manager.


### PR DESCRIPTION
Adds the drush command to modify site_manager to enable custom permissions provided by the `administerusersbyrole` module

Resolves https://github.com/CuBoulder/tiamat10-profile/issues/247

Includes:
- `drush-commands` => https://github.com/CuBoulder/ucb_drush_commands/pull/3
- `profile` => https://github.com/CuBoulder/tiamat10-profile/pull/253