### PR TITLE
Identikey Drush Command

### DIFF
--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -471,6 +471,15 @@ final class UcbDrushCommands extends DrushCommands {
             $username = $user->getAccountName();
             $email = $user->getEmail();
 
+            // Skip if username contains "admin" (case-insensitive).
+            if (stripos($username, 'admin') !== FALSE) {
+                $this->logger()->notice(dt('Skipping user @username - username contains "admin".', [
+                    '@username' => $username,
+                ]));
+                $skipped_count++;
+                continue;
+            }
+
             // Skip if no email address.
             if (empty($email)) {
                 $this->logger()->warning(dt('User @username does not have an email address.', ['@username' => $username]));

--- a/src/Drush/Commands/UcbDrushCommands.php
+++ b/src/Drush/Commands/UcbDrushCommands.php
@@ -482,6 +482,16 @@ final class UcbDrushCommands extends DrushCommands {
             $email_parts = explode('@', $email);
             $identikey_from_email = $email_parts[0];
 
+            // Skip if identikey contains a period (e.g., Joshua.Nicholson@colorado.edu).
+            if (strpos($identikey_from_email, '.') !== FALSE) {
+                $this->logger()->notice(dt('Skipping user @username - email prefix contains a period: @email.', [
+                    '@username' => $username,
+                    '@email' => $email,
+                ]));
+                $skipped_count++;
+                continue;
+            }
+
             // Check if field exists.
             if (!$user->hasField('field_identikey')) {
                 $this->logger()->warning(dt('User @username does not have field_identikey field.', ['@username' => $username]));


### PR DESCRIPTION
Added new drush command for updating identikeys on current users.

Can use these commands to run the process:

`ddev drush ucb_drush_commands:set-identikey`

or

`ddev drush ucb-set-identikey`

or

`ddev drush ucbsi`